### PR TITLE
Possibilities for more control over rebuild.sh

### DIFF
--- a/scripts/rebuild-inc
+++ b/scripts/rebuild-inc
@@ -62,7 +62,7 @@ main ()
 
     # Main build
     cd $BUILD_DIR
-    ../AROS/configure --target=$CONFIGURE_TARGET --with-aros-toolchain-install=$TOOLCHAIN_DIR --with-portssources=$PORTS_DIR $CONFIGURE_OPTS
+    ../AROS/configure --target=$CONFIGURE_TARGET --with-aros-toolchain-install=$TOOLCHAIN_DIR --with-portssources=$PORTS_DIR $CONFIGURE_OPTS $EXTRA_CONFIGURE_OPTS
     make $MAKE_TARGET -j $MAKE_JOBS
     local MAKE_STATUS=$?
     if [[ $MAKE_STATUS = 0 ]] && [[ -n $MAKE_TARGET_2 ]]; then

--- a/scripts/rebuild-inc
+++ b/scripts/rebuild-inc
@@ -20,6 +20,10 @@ source $(pwd)/AROS/scripts/rebuild-conf
 
 main ()
 {
+    # MAKE_JOBS controls the number of parallel make jobs
+    if  [ x$MAKE_JOBS = x ]; then
+        MAKE_JOBS=3
+    fi
     printf "rebuild v1.9, select an option:\n"
     printf "    0)  exit\n"
 
@@ -59,14 +63,14 @@ main ()
     # Main build
     cd $BUILD_DIR
     ../AROS/configure --target=$CONFIGURE_TARGET --with-aros-toolchain-install=$TOOLCHAIN_DIR --with-portssources=$PORTS_DIR $CONFIGURE_OPTS
-    make $MAKE_TARGET -j 3
+    make $MAKE_TARGET -j $MAKE_JOBS
     local MAKE_STATUS=$?
     if [[ $MAKE_STATUS = 0 ]] && [[ -n $MAKE_TARGET_2 ]]; then
-        make $MAKE_TARGET_2 -j 3
+        make $MAKE_TARGET_2 -j $MAKE_JOBS
         MAKE_STATUS=$?
     fi
     if [[ $MAKE_STATUS = 0 ]] && [[ -n $MAKE_TARGET_3 ]]; then
-        make $MAKE_TARGET_3 -j 3
+        make $MAKE_TARGET_3 -j $MAKE_JOBS
         MAKE_STATUS=$?
     fi
     cd ..


### PR DESCRIPTION
This PR makes it possible to specify more rebuild.sh behavior through environment variables MAKE_JOBS and EXTRA_CONFIGURE_OPTS.

Examples:

./rebuild.sh
- Works the same way as before

 MAKE_JOBS=6 EXTRA_CONFIGURE_OPTS=--with-gcc-version=8.3.0 ./rebuild.sh
- make will be called with -j 6 instead of the default -j 3, and --with-gcc-version=8.3.0 is added to the configure options.
