### PR TITLE
Fix bootdisk build for amiga-m68k target

### DIFF
--- a/tools/zopfli/mmakefile.src
+++ b/tools/zopfli/mmakefile.src
@@ -28,7 +28,8 @@ USER_LDFLAGS :=
 
 %build_linklib mmake=host-linklibs-zopfli \
     libname=zopfli files="$(ZOPFLILIB_SRC)" compiler=host \
-    objdir="$(HOSTGENDIR)/$(CURDIR)/lib" libdir="$(CROSSTOOLSDIR)/lib"
+    cflags=$(HOST_CFLAGS) objdir="$(HOSTGENDIR)/$(CURDIR)/lib" \
+    libdir="$(CROSSTOOLSDIR)/lib"
 
 HOST_LDFLAGS += -L$(CROSSTOOLSDIR)/lib -lzopfli -lm
 


### PR DESCRIPTION
For the amiga-m68k target, "make bootdisk" failed because host-linklibs-zopfli could not build. The build was using target cflags for the host compiler, which did not work out.

Now host-linklibs-zopfli uses HOST_CFLAGS, and "make bootdisk" creates the adf file.
