### PR TITLE
Update wpeditor.c

### DIFF
--- a/workbench/prefs/wanderer/wpeditor.c
+++ b/workbench/prefs/wanderer/wpeditor.c
@@ -1245,7 +1245,7 @@ D(bug("[WPEditor] WPEditor__OM_NEW()\n"));
 
 
 
-    _WP_Toolbar_PreviewDirUpObj = ImageButton("", "THEME:Images/Gadgets/Revert");
+    _WP_Toolbar_PreviewDirUpObj = ImageButton("", "THEME:Images/Gadgets/DirUp");
     _WP_Toolbar_PreviewSearchObj = ImageButton("", "THEME:Images/Gadgets/Search");
 /*END _WP_Toolbar_GroupObj---------------------------------------------------*/
 


### PR DESCRIPTION
In the Prefs/Wanderer under the Toolbar tab, the Toolbar can be switched on or off. There is also a preview of the Toolbar's appearance. The Toolbar currently has two icons assigned to it - DirUp and Search.

There is an error in the Toolbar preview, as it displays the Revert icon instead of the DirUp icon. This commit changes the path to the DirUp icon.