### PR TITLE
Fix incorrect kprintf logging of QUAD values on m68k.

### DIFF
--- a/compiler/fmtprintf/fmtprintf_pre.c
+++ b/compiler/fmtprintf/fmtprintf_pre.c
@@ -23,7 +23,7 @@
                         (MININTSIZE>MINFLOATSIZE?MININTSIZE:MINFLOATSIZE): \
                         (MINPOINTSIZE>MINFLOATSIZE?MINPOINTSIZE:MINFLOATSIZE))
 #else
-#define REQUIREDBUFFER (MININTSIZE>MINPOINTSIZE ? (MININTSIZE) : (MINPOINTSIZE))
+#define REQUIREDBUFFER 17 // Hexadecimal output of QUAD needs 16 characters
 #endif
 #define ALTERNATEFLAG 1  /* '#' is set */
 #define ZEROPADFLAG   2  /* '0' is set */


### PR DESCRIPTION
The buffer used for writing the string representation of the number was too small to house a QUAD, so the string would overflow. The buffer is now large enough.
