### PR TITLE
Fix m68k double precision software multiplication

### DIFF
--- a/workbench/libs/mathieeedoubbas/ieeedpmul.c
+++ b/workbench/libs/mathieeedoubbas/ieeedpmul.c
@@ -109,18 +109,18 @@ static void add128(ULONG *s, ULONG *d)
     t1[3] = Get_Low32of64(Qtmp1);
 
     Qtmp1 = UMult64(x1, y2);
-    t2[3] = 0;
-    t2[2] = Get_High32of64(Qtmp1);
-    t2[1] = Get_Low32of64(Qtmp1);
     t2[0] = 0;
+    t2[1] = Get_High32of64(Qtmp1);
+    t2[2] = Get_Low32of64(Qtmp1);
+    t2[3] = 0;
 
     add128(t2, t1);
 
     Qtmp1 = UMult64(x2, y1);
-    t2[3] = 0;
-    t2[2] = Get_High32of64(Qtmp1);
-    t2[1] = Get_Low32of64(Qtmp1);
     t2[0] = 0;
+    t2[1] = Get_High32of64(Qtmp1);
+    t2[2] = Get_Low32of64(Qtmp1);
+    t2[3] = 0;
 
     add128(t2, t1);
 

--- a/workbench/libs/mathieeedoubbas/ieeedpmul.c
+++ b/workbench/libs/mathieeedoubbas/ieeedpmul.c
@@ -174,7 +174,7 @@ static void add128(ULONG *s, ULONG *d)
     OR64Q(res, Qtmp1);
 
     if (sign)
-        OR64(res, IEEEDPSign_Mask_Hi, IEEEDPSign_Mask_Lo);
+        OR64QC(res, IEEEDPSign_Mask_Hi, IEEEDPSign_Mask_Lo);
 
     return *Dres;
 


### PR DESCRIPTION
There were a couple of issues with software multiplication of doubles (IEEEDPMul):

1) The accuracy was poor because index 1 and 2 of an intermediate result array were erroneously swapped.

2) All negative results ended up being the same result.

This also had effects on other soft double functions using IEEEDPMul, like IEEEDPCos and IEEEDPSin.
