### PR TITLE
wcsncat function porting from Haiku

### DIFF
--- a/compiler/crt/mmakefile.src
+++ b/compiler/crt/mmakefile.src
@@ -376,6 +376,7 @@ USER_CPPFLAGS := \
 # wide char/string support
 STDLIB_WCHAR := \
     stdc/wcschr \
+    stdc/wcsncat \
     stdc/wcscat \
     stdc/wcscmp \
     stdc/wcsncmp \

--- a/compiler/crt/stdc/include/aros/stdc/wchar.h
+++ b/compiler/crt/stdc/include/aros/stdc/wchar.h
@@ -68,7 +68,7 @@ __BEGIN_DECLS
 	wchar_t ** restrict endptr, int base); */
 
 wchar_t *wcscat(wchar_t * restrict s1, const wchar_t * restrict s2);
-/* NOTIMPL wchar_t *wcsncat(wchar_t * restrict s1, const wchar_t * restrict s2, size_t n); */
+wchar_t *wcsncat(wchar_t * restrict s1, const wchar_t * restrict s2, size_t n);
 int wcscmp(const wchar_t *s1, const wchar_t *s2);
 wchar_t *wcscpy(wchar_t *s1, const wchar_t *s2);
 /* NOTIMPL int wcscoll(const wchar_t *s1, const wchar_t *s2); */

--- a/compiler/crt/stdc/wcsncat.c
+++ b/compiler/crt/stdc/wcsncat.c
@@ -1,0 +1,52 @@
+/*
+** Copyright 2011, Oliver Tappe, zooey@hirschkaefer.de. All rights reserved.
+** Distributed under the terms of the MIT License.
+*/
+
+#include <wchar.h>
+
+/*****************************************************************************
+
+    NAME */
+
+wchar_t *wcsncat(
+
+/*  SYNOPSIS */
+    wchar_t * restrict s1, 
+    const wchar_t * restrict s2, 
+    size_t n)
+
+/*  FUNCTION
+         Appends not more than n wide characters from the array pointed to by s2 to the end of the wide string pointed to by s1.
+
+    INPUTS
+        s1 - specifies the pointer to the destination array.
+        s2 - specifies the string to be added to the destination.
+        n  - specifies the maximum number of wide characters to be added.
+
+    RESULT
+        Returns the value of s1.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+
+    INTERNALS
+
+******************************************************************************/
+{
+	wchar_t* dest = s1;
+	const wchar_t* srcEnd = s2 + n;
+
+	while (*dest != L'\0')
+		dest++;
+	while (s2 < srcEnd && *s2 != L'\0')
+		*dest++ = *s2++;
+	*dest = L'\0';
+
+	return s1;
+}

--- a/compiler/crt/stdlib.conf
+++ b/compiler/crt/stdlib.conf
@@ -240,8 +240,7 @@ char *__wcscpy_wchar_t_8(char *wcdst, const char *wcsrc)
 #size_t wcsftime(wchar_t *, size_t, const wchar_t *, const struct tm *)
 size_t __wcslen_wchar_t_8(const char *wcstr)
 .private
-.skip 1
-#wchar_t *wcsncat(wchar_t *, const wchar_t *, size_t)
+wchar_t *wcsncat(wchar_t * restrict s1, const wchar_t * restrict s2, size_t n)
 int __wcsncmp_wchar_t_8(const char *wcstra, const char *wcstrb, size_t cnt)
 .private
 char *__wcsncpy_wchar_t_8(char *wcdst, const char *wcsrc, size_t cnt)

--- a/developer/debug/test/crt/stdc/cunit-crt-wcsncat.c
+++ b/developer/debug/test/crt/stdc/cunit-crt-wcsncat.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <wchar.h>
+#include <CUnit/CUnitCI.h>
+
+// Function to test wcsncat
+static void test_wcsncat_1() {
+    wchar_t dest[50] = L"Hello, ";
+    wchar_t src[] = L"World!";
+
+    // Test case 1: Normal concatenation
+    wchar_t *result = wcsncat(dest, src, 6); // Concatenate "World!"
+    CU_ASSERT_PTR_NOT_NULL(result);
+    CU_ASSERT(wcscmp(dest, L"Hello, World!") == 0);
+
+    // Reset dest for the next test
+    wcscpy(dest, L"Hello, ");
+}
+static void test_wcsncat_2() {
+    wchar_t dest[50] = L"Hello, ";
+    wchar_t src[] = L"World!";
+
+    // Test case 2: Concatenation with limit less than source length
+    wchar_t *result = wcsncat(dest, src, 3); // Concatenate "Wor"
+    CU_ASSERT_PTR_NOT_NULL(result);
+    CU_ASSERT(wcscmp(dest, L"Hello, Wor") == 0);
+
+    // Reset dest for the next test
+    wcscpy(dest, L"Hello, ");
+}
+static void test_wcsncat_3() {
+    wchar_t dest[50] = L"Hello, ";
+    wchar_t src[] = L"World!";
+
+    // Test case 3: Concatenation with limit equal to source length
+    wchar_t *result = wcsncat(dest, src, 6); // Concatenate "World!"
+    CU_ASSERT_PTR_NOT_NULL(result);
+    CU_ASSERT(wcscmp(dest, L"Hello, World!") == 0);
+
+    // Reset dest for the next test
+    wcscpy(dest, L"Hello, ");
+}
+static void test_wcsncat_4() {
+    wchar_t dest[50] = L"Hello, ";
+    wchar_t src[] = L"World!";
+
+    // Test case 4: Concatenation with limit of 0
+    wchar_t *result = wcsncat(dest, src, 0); // Concatenate nothing
+    CU_ASSERT_PTR_NOT_NULL(result);
+    CU_ASSERT(wcscmp(dest, L"Hello, ") == 0);
+}
+
+// Main function to run the tests
+int main(int argc, char** argv) {
+    //Define test suite
+    CU_CI_DEFINE_SUITE("wcsncat_Suite", NULL, NULL, NULL, NULL);
+    CUNIT_CI_TEST(test_wcsncat_1);
+    CUNIT_CI_TEST(test_wcsncat_2);
+    CUNIT_CI_TEST(test_wcsncat_3);
+    CUNIT_CI_TEST(test_wcsncat_4);
+
+    return CU_CI_RUN_SUITES();
+}

--- a/developer/debug/test/crt/stdc/mmakefile.src
+++ b/developer/debug/test/crt/stdc/mmakefile.src
@@ -48,6 +48,7 @@ CUNITSTDCTESTFILES := \
     cunit-crt-time \
     cunit-crt-wcsncpy \
     cunit-crt-wcscat \
+    cunit-crt-wcsncat \
     cunit-crt-wcscpy \
     cunit-crt-wcslen \
     cunit-crt-wcschr \

--- a/scripts/nightly/autotest/User-Startup.cunit
+++ b/scripts/nightly/autotest/User-Startup.cunit
@@ -60,6 +60,7 @@ If NOT WARN
     Execute S/Test cunit/crt/stdc/cunit-crt-wcsncmp             ;wcsncmp_Suite
     Execute S/Test cunit/crt/stdc/cunit-crt-wcsncpy             ;wcsncpy_Suite
     Execute S/Test cunit/crt/stdc/cunit-crt-wcschr              ;wcschr_Suite
+    Execute S/Test cunit/crt/stdc/cunit-crt-wcsncat             ;wcsncat_Suite
     Execute S/Test cunit/crt/posix/cunit-crt-fread              ;fread_Suite
     Copy SYS:Development/Debug/Tests/crt/posix/execl2_slave SYS:
     Execute S/Test cunit/crt/posix/cunit-crt-vfork              ;vfork_Suite
@@ -93,7 +94,7 @@ If NOT WARN
     Execute S/Test cunit/cplusplus/cunit-cplusplus-static       ;CPlusPlus_Static_Suite
 
     Echo "===================" >DEBUG:
-    Echo "Expected tests: 279" >DEBUG:
+    Echo "Expected tests: 289" >DEBUG:
     Echo "===================" >DEBUG:
 Endif
 


### PR DESCRIPTION
wcsncat function porting from Haiku

- adapted variables to AROS
- added cunit test
- exposed wcsncat function