### PR TITLE
Fix mouse pointer corruption and availability of wide mouse pointers on AGA chipset

### DIFF
--- a/arch/m68k-amiga/graphics/mmakefile.src
+++ b/arch/m68k-amiga/graphics/mmakefile.src
@@ -4,11 +4,14 @@ include $(SRCDIR)/config/aros.cfg
 CFILES  := setchiprev vbeampos
 AFILES  := attemptlocklayerrom locklayerrom unlocklayerrom waitblit
 
-#MM kernel-graphics-amiga-m68k : kernel-hidd-includes kernel-graphics-includes includes-asm_h kernel-hidd-graphics-includes
+#MM kernel-graphics-amiga-m68k : kernel-amiga-m68k-amigavideo kernel-hidd-includes kernel-graphics-includes includes-asm_h kernel-hidd-graphics-includes
 
 USER_INCLUDES := -I$(SRCDIR)/arch/$(CPU)-$(ARCH)/graphics \
                -I$(SRCDIR)/rom/graphics
-USER_CPPFLAGS := -D__GRAPHICS_NOHIDDBASE__ -DDoRegisterCalls
+USER_CPPFLAGS := -D__GRAPHICS_NOHIDDBASE__ \
+                 -D__OOP_RELLIBBASE__ \
+                 -D__UTILITY_RELLIBBASE__ \
+                 -DDoRegisterCalls
 USER_AFLAGS := -I$(GENINCDIR)
 TARGET_ISA_AFLAGS := $(ISA_MC68060_FLAGS)
 

--- a/arch/m68k-amiga/graphics/setchiprev.c
+++ b/arch/m68k-amiga/graphics/setchiprev.c
@@ -7,9 +7,39 @@
 #include <graphics/gfxbase.h>
 #include <hardware/custom.h>
 
+#include "graphics_intern.h"
+
+#include <interface/HW.h>
+#include <interface/Hidd_AmigaGfx.h>
+
 #include <proto/graphics.h>
+#include <proto/oop.h>
+
+#include <string.h>
 
 /* See rom/graphics/setchiprev.c for documentation */
+
+struct GfxHookData
+{
+    OOP_Object  *amigavideo_driver;
+};
+
+AROS_UFH3S(BOOL, enum_cb,
+           AROS_UFHA(struct Hook *, hook, A0),
+           AROS_UFHA(OOP_Object *, obj, A2),
+           AROS_UFHA(APTR, data, A1))
+{
+    AROS_USERFUNC_INIT
+    struct GfxHookData *_data = (struct GfxHookData *)data;
+    if (OOP_OCLASS(obj)->ClassNode.ln_Name && (!strcmp(OOP_OCLASS(obj)->ClassNode.ln_Name, "hidd.gfx.amigavideo"))) {
+        _data->amigavideo_driver = obj;
+        return TRUE;
+    }
+    else {
+        return FALSE;
+    }
+    AROS_USERFUNC_EXIT
+}
 
 AROS_LH1(ULONG, SetChipRev,
     AROS_LHA(ULONG, ChipRev, D0),
@@ -20,6 +50,7 @@ AROS_LH1(ULONG, SetChipRev,
     volatile struct Custom *custom = (struct Custom*)0xdff000;
     UWORD vposr, deniseid1, deniseid2, deniseid3;
     UBYTE chipflags = 0;
+    UBYTE best_possible_flags = GFXF_AA_ALICE | GFXF_HR_AGNUS | GFXF_AA_LISA | GFXF_HR_DENISE | GFXF_AA_MLISA;
 
     vposr = custom->vposr & 0x7f00;
     if ((vposr & 0x0200) == 0x0200) {
@@ -27,8 +58,8 @@ AROS_LH1(ULONG, SetChipRev,
     } else if (vposr >= 0x2000) {
         chipflags = GFXF_HR_AGNUS;
         // ECS Agnus can be combined with different Denise chips.
-        // DENISEID register does not exist in original Denise.
-        // The hack below is likely intended to handle that case.
+        // DENISEID register does not exist in original Denise,
+        // so one cannot just read it once and trust it.
         Disable();
         deniseid1 = custom->deniseid & 0x00ff;
         custom->deniseid = custom->dmaconr;
@@ -49,6 +80,25 @@ AROS_LH1(ULONG, SetChipRev,
             chipflags = SETCHIPREV_AA;
     }
     GfxBase->ChipRevBits0 = chipflags;
+
+    // Notify the amigavideo driver if AGA is enabled
+    if (chipflags == best_possible_flags || chipflags == SETCHIPREV_AA) {
+        struct Hook enum_hook =
+        {
+            .h_Entry = enum_cb
+        };
+        struct GfxHookData hook_data =
+        {
+            .amigavideo_driver = NULL
+        };
+        APTR gfxroot = ((struct GfxBase_intern *)GfxBase)->GfxRoot;
+        HW_EnumDrivers(gfxroot, &enum_hook, &hook_data);
+        // The amigavideo HIDD should be found on this arch, but check anyway
+        if (hook_data.amigavideo_driver) {
+            OOP_MethodID HiddAmigaGfxBase = OOP_GetMethodID(IID_Hidd_AmigaGfx, 0);
+            HIDD_AMIGAGFX_EnableAGA(hook_data.amigavideo_driver);
+        }
+    }
 
     return GfxBase->ChipRevBits0;
 

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
@@ -47,6 +47,8 @@ MakeViewPort
 CleanViewPort
 DisplayToBMCoords
 BMToDisplayCoords
+.interface Hidd_AmigaGfx
+EnableAGA
 ##end methodlist
 
 
@@ -104,3 +106,17 @@ BitMapPositionChanged
 ValidateBitMapPositionChange
 ##end methodlist
 ##end class
+
+##begin interface
+##begin config
+interfaceid   hidd.gfx.amiga
+interfacename Hidd_AmigaGfx
+methodstub    HIDD_AMIGAGFX
+methodbase    HiddAmigaGfxBase
+attributebase HiddAmigaGfxAttrBase
+##end config
+
+##begin methodlist
+VOID EnableAGA()
+##end methodlist
+##end interface

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
@@ -2,7 +2,7 @@
 basename 	AmigaVideoCl
 libbase 	AmigaVideoClBase
 libbasetype 	struct amigavideoclbase
-version 	45.8
+version 	45.9
 residentpri     9
 classid         CLID_Hidd_Gfx_AmigaVideo
 superclass      CLID_Hidd_Gfx

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_hidd.h
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_hidd.h
@@ -7,6 +7,7 @@
 #include <exec/interrupts.h>
 #include <graphics/gfxbase.h>
 #include <graphics/copper.h>
+#include <interface/Hidd_AmigaGfx.h>
 
 #include "amigavideo_intern.h"
 

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
@@ -867,7 +867,7 @@ BOOL AmigaVideoCl__Hidd_Gfx__SetCursorShape(OOP_Class *cl, OOP_Object *o, struct
     OOP_GetAttr(msg->shape, aHidd_BitMap_Width, &width);
     OOP_GetAttr(msg->shape, aHidd_BitMap_Height, &height);
 
-    maxw = (csd->aga ? 64 : 16);
+    maxw = (csd->aga_enabled ? 64 : 16);
     maxh = maxw * 2;
 
     if (width > maxw || height > maxh)

--- a/arch/m68k-amiga/hidd/amigavideo/mmakefile.src
+++ b/arch/m68k-amiga/hidd/amigavideo/mmakefile.src
@@ -20,4 +20,4 @@ USER_CPPFLAGS += \
 
 %build_module mmake=kernel-amiga-m68k-amigavideo \
     modname=amigavideo modtype=hidd \
-    files="$(AMIGAVIDEO_C_SOURCES)" uselibs="hiddstubs" usesdks="private"
+    files="$(AMIGAVIDEO_C_SOURCES)" uselibs="hiddstubs" sdk=private usesdks="private"


### PR DESCRIPTION
1) Running setpatch now makes wide mouse pointers available without having to change screenmode to a mode that requires AGA.
2) Wide mouse pointers are no longer corrupted, and switching between wide and standard pointers no longer corrupts any pointers.
