### PR TITLE
Path and parsing fixes

### DIFF
--- a/workbench/prefs/boot/booteditor.c
+++ b/workbench/prefs/boot/booteditor.c
@@ -32,8 +32,8 @@
 #define DEFAULT_REFRESH 60
 #define MAX_LINE_LENGTH 500
 
-static const TEXT grub_config_path[] = "SYS:boot/pc/grub/grub.cfg";
-static const TEXT grub_config_path_tmp[] = "SYS:boot/pc/grub/grub.cfg.tmp";
+static const TEXT grub_config_path[] = "SYS:boot/grub/grub.cfg";
+static const TEXT grub_config_path_tmp[] = "SYS:boot/grub/grub.cfg.tmp";
 static const TEXT accept_nums[] = "0123456789";
 static CONST_STRPTR ata_buses_list[5] = {NULL};
 static CONST_STRPTR debug_output_list[4] = {NULL};
@@ -880,8 +880,9 @@ static BOOL ReadBootArgs(CONST_STRPTR line, struct BootEditor_DATA *data)
 
         /* Check for user-set refresh rate */
 
-        if (*(options - 1) == '@')
+        if (*options == '@')
         {
+            options++;
             while (*options >= '0' && *options <= '9')
                 refresh = refresh * 10 + *options++ - '0';
             use_refresh = TRUE;


### PR DESCRIPTION
Correction of the path to the configuration file.
Badly set pointer did not read the “@” sign due to which user refresh settings were not read.