### PR TITLE
muimaster: When applying MUI settings, only re-open the windows that …

### DIFF
--- a/workbench/libs/muimaster/classes/application.c
+++ b/workbench/libs/muimaster/classes/application.c
@@ -2076,32 +2076,55 @@ static IPTR Application__MUIM_AboutMUI(struct IClass *cl, Object *obj,
 }
 
 
-static void Application__CloseWindows(struct IClass *cl, Object *obj)
+static struct List *Application__CloseWindows(struct IClass *cl, Object *obj)
 {
     struct MUI_ApplicationData *data = INST_DATA(cl, obj);
     struct MinList *children = NULL;
+    struct List *windows = NULL;
     Object *cstate;
     Object *child;
 
     get(data->app_WindowFamily, MUIA_Family_List, &children);
-    if (children)
-    {
-        cstate = (Object *) children->mlh_Head;
-        while ((child = NextObject(&cstate)))
-        {
-            D(bug("[MUI:App] %s: closing window %p\n", __func__, child));
+    if (!children)
+        return NULL;
 
+    /* remember which windows were open, so they can be re-opened after a
+     * configdata change. Windows that were already closed are left alone. */
+    windows = AllocVec(sizeof(struct List), MEMF_CLEAR);
+    if (windows)
+        NewList(windows);
+
+    cstate = (Object *) children->mlh_Head;
+    while ((child = NextObject(&cstate)))
+    {
+        if (XGET(child, MUIA_Window_Open))
+        {
+            if (windows)
+            {
+                struct Node *n = AllocVec(sizeof(struct Node), MEMF_CLEAR);
+
+                if (n)
+                {
+                    n->ln_Name = (STRPTR)child;
+                    AddTail(windows, n);
+                }
+            }
+            D(bug("[MUI:App] %s: closing window %p\n", __func__, child));
             set(child, MUIA_Window_Open, FALSE);
         }
     }
+    return windows;
 }
 
 static IPTR Application__MUIM_SetConfigdata(struct IClass *cl, Object *obj,
     struct MUIP_Application_SetConfigdata *msg)
 {
     struct MUI_ApplicationData *data = INST_DATA(cl, obj);
+    struct List *windows;
 
-    Application__CloseWindows(cl, obj);
+    /* close all currently open windows and remember them, so they can be
+     * re-opened with the new settings afterwards */
+    windows = Application__CloseWindows(cl, obj);
 
     if (data->app_GlobalInfo.mgi_Configdata)
         MUI_DisposeObject(data->app_GlobalInfo.mgi_Configdata);
@@ -2109,8 +2132,8 @@ static IPTR Application__MUIM_SetConfigdata(struct IClass *cl, Object *obj,
     get(data->app_GlobalInfo.mgi_Configdata, MUIA_Configdata_ZunePrefs,
         &data->app_GlobalInfo.mgi_Prefs);
 
-    DoMethod(obj, MUIM_Application_PushMethod, (IPTR) obj, 1,
-        MUIM_Application_OpenWindows);
+    DoMethod(obj, MUIM_Application_PushMethod, (IPTR) obj, 2,
+        MUIM_Application_OpenWindows, (IPTR) windows);
     return 0;
 }
 
@@ -2208,10 +2231,14 @@ static IPTR Application__MUIM_SetConfigItem(struct IClass *cl, Object *obj,
             case MUICFG_String_MarkedText:
             case MUICFG_ActiveObject_Color:
             case MUICFG_PublicScreen:
-                Application__CloseWindows(cl, obj);
-                DoMethod(data->app_GlobalInfo.mgi_Configdata, MUIM_Configdata_SetString, msg->item, msg->data);
-                DoMethod(obj, MUIM_Application_PushMethod, (IPTR) obj, 1,
-                    MUIM_Application_OpenWindows);
+                {
+                    struct List *windows;
+
+                    windows = Application__CloseWindows(cl, obj);
+                    DoMethod(data->app_GlobalInfo.mgi_Configdata, MUIM_Configdata_SetString, msg->item, msg->data);
+                    DoMethod(obj, MUIM_Application_PushMethod, (IPTR) obj, 2,
+                        MUIM_Application_OpenWindows, (IPTR) windows);
+                }
                 break;
         }
     }
@@ -2226,18 +2253,38 @@ static IPTR Application__MUIM_OpenWindows(struct IClass *cl, Object *obj,
     struct MUIP_Application_OpenWindows *msg)
 {
     struct MUI_ApplicationData *data = INST_DATA(cl, obj);
-    struct MinList *children = NULL;
-    Object *cstate;
-    Object *child;
 
-    get(data->app_WindowFamily, MUIA_Family_List, &children);
-    if (!children)
-        return 0;
-
-    cstate = (Object *) children->mlh_Head;
-    while ((child = NextObject(&cstate)))
+    /* a list of windows to open was passed (e.g. the ones closed by
+     * Application__CloseWindows before a configdata change) - open exactly
+     * those and free the list */
+    if (msg->windows)
     {
-        set(child, MUIA_Window_Open, TRUE);
+        struct Node *n;
+
+        while ((n = (struct Node *)RemHead(msg->windows)))
+        {
+            set((Object *)n->ln_Name, MUIA_Window_Open, TRUE);
+            FreeVec(n);
+        }
+        FreeVec(msg->windows);
+        return 0;
+    }
+
+    /* otherwise open all windows of the application */
+    {
+        struct MinList *children = NULL;
+        Object *cstate;
+        Object *child;
+
+        get(data->app_WindowFamily, MUIA_Family_List, &children);
+        if (!children)
+            return 0;
+
+        cstate = (Object *) children->mlh_Head;
+        while ((child = NextObject(&cstate)))
+        {
+            set(child, MUIA_Window_Open, TRUE);
+        }
     }
     return 0;
 }

--- a/workbench/libs/muimaster/classes/application.h
+++ b/workbench/libs/muimaster/classes/application.h
@@ -176,6 +176,7 @@ struct MUIP_Application_SetConfigdata
 struct MUIP_Application_OpenWindows
 {
     STACKED ULONG MethodID;
+    STACKED struct List *windows;    /* windows to open, NULL = all */
 };
 
 struct MUIP_Application_UpdateMenus


### PR DESCRIPTION
…were open

When the application's Configdata was replaced
(MUIM_Application_SetConfigdata / MUIM_Application_SetConfigItem), Application__CloseWindows() closed every window and MUIM_Application_OpenWindows() reopened all of them. OpenWindows opens the whole window family, so for applications that create several windows up front (e.g. via SubWindow) every window popped up again after a settings change, even ones the user had closed.

Let Application__CloseWindows() return the list of windows it closed (only the ones that were open) and make MUIM_Application_OpenWindows() accept that list as an optional argument, opening exactly those windows. The close/reload/open sequence and the deferred open through MUIM_Application_PushMethod are kept.